### PR TITLE
Add livedisplay driver

### DIFF
--- a/drivers/video/msm/mdss/Makefile
+++ b/drivers/video/msm/mdss/Makefile
@@ -55,3 +55,5 @@ obj-$(CONFIG_FB_MSM_QPIC_ILI_QVGA_PANEL) += qpic_panel_ili_qvga.o
 
 obj-$(CONFIG_FB_MSM_MDSS) += mdss_fb.o mdss_util.o
 obj-$(CONFIG_COMPAT) += mdss_compat_utils.o
+
+obj-$(CONFIG_FB_MSM_MDSS) += mdss_livedisplay.o

--- a/drivers/video/msm/mdss/mdss_dsi_panel.c
+++ b/drivers/video/msm/mdss/mdss_dsi_panel.c
@@ -25,6 +25,7 @@
 
 #include "mdss_dsi.h"
 #include "mdss_dba_utils.h"
+#include "mdss_livedisplay.h"
 
 #define DT_CMD_HDR 6
 #define MIN_REFRESH_RATE 48
@@ -152,7 +153,7 @@ u32 mdss_dsi_panel_cmd_read(struct mdss_dsi_ctrl_pdata *ctrl, char cmd0,
 	return 0;
 }
 
-static void mdss_dsi_panel_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl,
+void mdss_dsi_panel_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl,
 			struct dsi_panel_cmds *pcmds, u32 flags)
 {
 	struct dcs_cmd_req cmdreq;
@@ -770,6 +771,8 @@ static int mdss_dsi_post_panel_on(struct mdss_panel_data *pdata)
 		mdss_dba_utils_hdcp_enable(pinfo->dba_data, true);
 	}
 
+	mdss_livedisplay_update(ctrl, MODE_UPDATE_ALL);
+
 end:
 	pr_debug("%s:-\n", __func__);
 	return 0;
@@ -853,7 +856,7 @@ static void mdss_dsi_parse_trigger(struct device_node *np, char *trigger,
 }
 
 
-static int mdss_dsi_parse_dcs_cmds(struct device_node *np,
+int mdss_dsi_parse_dcs_cmds(struct device_node *np,
 		struct dsi_panel_cmds *pcmds, char *cmd_key, char *link_key)
 {
 	const char *data;
@@ -2358,6 +2361,8 @@ static int mdss_panel_parse_dt(struct device_node *np,
 
 	pinfo->is_dba_panel = of_property_read_bool(np,
 			"qcom,dba-panel");
+
+	mdss_livedisplay_parse_dt(np, pinfo);
 
 	return 0;
 

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -56,6 +56,8 @@
 #define CREATE_TRACE_POINTS
 #include "mdss_debug.h"
 
+#include "mdss_livedisplay.h"
+
 #ifdef CONFIG_FB_MSM_TRIPLE_BUFFER
 #define MDSS_FB_NUM 3
 #else
@@ -816,7 +818,8 @@ static int mdss_fb_create_sysfs(struct msm_fb_data_type *mfd)
 	rc = sysfs_create_group(&mfd->fbi->dev->kobj, &mdss_fb_attr_group);
 	if (rc)
 		pr_err("sysfs group creation failed, rc=%d\n", rc);
-	return rc;
+
+	return mdss_livedisplay_create_sysfs(mfd);
 }
 
 static void mdss_fb_remove_sysfs(struct msm_fb_data_type *mfd)

--- a/drivers/video/msm/mdss/mdss_livedisplay.c
+++ b/drivers/video/msm/mdss/mdss_livedisplay.c
@@ -136,7 +136,6 @@ exit_free:
  */
 static int mdss_livedisplay_set_rgb_locked(struct msm_fb_data_type *mfd)
 {
-	u32 copyback = 0;
 	static struct mdp_pcc_cfg_data pcc_cfg;
 	struct mdss_livedisplay_ctx *mlc;
 
@@ -159,7 +158,7 @@ static int mdss_livedisplay_set_rgb_locked(struct msm_fb_data_type *mfd)
 	pcc_cfg.g.g = mlc->g;
 	pcc_cfg.b.b = mlc->b;
 
-	return mdss_mdp_pcc_config(&pcc_cfg, &copyback);
+	return mdss_mdp_user_pcc_config(&pcc_cfg);
 }
 
 /*

--- a/drivers/video/msm/mdss/mdss_livedisplay.c
+++ b/drivers/video/msm/mdss/mdss_livedisplay.c
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2015 The CyanogenMod Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/err.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/slab.h>
+#include <linux/sysfs.h>
+
+#include "mdss_dsi.h"
+#include "mdss_fb.h"
+#include "mdss_mdp.h"
+#include "mdss_livedisplay.h"
+
+
+extern void mdss_dsi_panel_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl,
+		struct dsi_panel_cmds *pcmds);
+
+extern int mdss_dsi_parse_dcs_cmds(struct device_node *np,
+		struct dsi_panel_cmds *pcmds, char *cmd_key, char *link_key);
+
+
+static int mdss_livedisplay_update_locked(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
+		int types)
+{
+	int ret = 0;
+	struct mdss_panel_info *pinfo = NULL;
+	struct mdss_livedisplay_ctx *mlc = NULL;
+
+	if (ctrl_pdata == NULL)
+		return -ENODEV;
+
+	pinfo = &(ctrl_pdata->panel_data.panel_info);
+	if (pinfo == NULL)
+		return -ENODEV;
+
+	mlc = pinfo->livedisplay;
+	if (mlc == NULL)
+		return -ENODEV;
+
+	if (!mlc->caps || !mdss_panel_is_power_on_interactive(pinfo->panel_power_state))
+		return 0;
+
+	if (mlc->caps & MODE_CABC && (types & MODE_CABC || types & MODE_SRE)) {
+
+		pr_info("%s: update cabc level=%d  sre=%d\n", __func__,
+				mlc->cabc_mode, mlc->sre_enabled);
+
+		if ((mlc->caps & MODE_SRE) && mlc->sre_enabled) {
+			mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_sre_cmd));
+		} else {
+
+			switch (mlc->cabc_mode)
+			{
+				case CABC_OFF:
+					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_off_cmd));
+					break;
+				case CABC_UI:
+					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_ui_cmd));
+					break;
+				case CABC_IMAGE:
+					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_image_cmd));
+					break;
+				case CABC_VIDEO:
+					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_video_cmd));
+					break;
+				default:
+					pr_err("%s: cabc level %d is not supported!\n",__func__, mlc->cabc_mode);
+					break;
+			}
+		}
+	}
+
+	if (mlc->caps & MODE_COLOR_ENHANCE && types & MODE_COLOR_ENHANCE) {
+		if (mlc->ce_enabled) {
+			mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->color_enhance_on_cmd));
+		} else {
+			mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->color_enhance_off_cmd));
+		}
+	}
+
+	return ret;
+}
+
+int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
+		int types)
+{
+	struct mdss_panel_info *pinfo;
+	struct mdss_livedisplay_ctx *mlc;
+	int ret = 0;
+
+	pinfo = &(ctrl_pdata->panel_data.panel_info);
+	if (pinfo == NULL)
+		return -ENODEV;
+
+	mlc = pinfo->livedisplay;
+
+	mutex_lock(&mlc->lock);
+	ret = mdss_livedisplay_update_locked(ctrl_pdata, types);
+	mutex_unlock(&mlc->lock);
+
+	return ret;
+}
+
+static struct mdss_livedisplay_ctx* get_ctx(struct msm_fb_data_type *mfd)
+{
+	return mfd->panel_info->livedisplay;
+}
+
+static struct mdss_dsi_ctrl_pdata* get_ctrl(struct msm_fb_data_type *mfd)
+{
+	struct mdss_panel_data *pdata = dev_get_platdata(&mfd->pdev->dev);
+	return container_of(pdata, struct mdss_dsi_ctrl_pdata, panel_data);
+}
+
+static ssize_t mdss_livedisplay_get_cabc(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);	
+
+	return sprintf(buf, "%d\n", mlc->cabc_mode);
+}
+
+static ssize_t mdss_livedisplay_set_cabc(struct device *dev,
+							   struct device_attribute *attr,
+							   const char *buf, size_t count)
+{
+	int level = 0;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	mutex_lock(&mlc->lock);
+
+	sscanf(buf, "%du", &level);
+	if (level >= CABC_OFF && level < CABC_MAX &&
+				level != mlc->cabc_mode) {
+		mlc->cabc_mode = level;
+		mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_CABC);
+	}
+
+	mutex_unlock(&mlc->lock);
+
+	return count;
+}
+
+static ssize_t mdss_livedisplay_get_sre(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	return sprintf(buf, "%d\n", mlc->sre_enabled);
+}
+
+static ssize_t mdss_livedisplay_set_sre(struct device *dev,
+							   struct device_attribute *attr,
+							   const char *buf, size_t count)
+{
+	int value = 0;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	mutex_lock(&mlc->lock);
+
+	sscanf(buf, "%du", &value);
+	if ((value == 0 || value == 1)
+			&& value != mlc->sre_enabled) {
+		mlc->sre_enabled = value;
+		mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_SRE);
+	}
+
+	mutex_unlock(&mlc->lock);
+
+	return count;
+}
+
+static ssize_t mdss_livedisplay_get_color_enhance(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	return sprintf(buf, "%d\n", mlc->ce_enabled);
+}
+
+static ssize_t mdss_livedisplay_set_color_enhance(struct device *dev,
+							   struct device_attribute *attr,
+							   const char *buf, size_t count)
+{
+	int value = 0;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	mutex_lock(&mlc->lock);
+
+	sscanf(buf, "%du", &value);
+	if ((value == 0 || value == 1)
+			&& value != mlc->ce_enabled) {
+		mlc->ce_enabled = value;
+		mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_COLOR_ENHANCE);
+	}
+
+	mutex_unlock(&mlc->lock);
+
+	return count;
+}
+
+static ssize_t mdss_livedisplay_get_rgb(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	u32 copyback = 0;
+	struct mdp_pcc_cfg_data pcc_cfg;
+	unsigned int pcc_r = 32768, pcc_g = 32768, pcc_b = 32768;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc;
+
+	if (mfd == NULL)
+		return -ENODEV;
+
+	mlc = get_ctx(mfd);
+	mutex_lock(&mlc->lock);
+
+	memset(&pcc_cfg, 0, sizeof(struct mdp_pcc_cfg_data));
+
+	pcc_cfg.block = mfd->index + MDP_LOGICAL_BLOCK_DISP_0;
+	pcc_cfg.ops = MDP_PP_OPS_READ;
+
+	mdss_mdp_pcc_config(&pcc_cfg, &copyback);
+
+	/* We disable pcc when using default values and reg
+	 * are zeroed on pp resume, so ignore empty values.
+	 */
+	if (pcc_cfg.r.r && pcc_cfg.g.g && pcc_cfg.b.b) {
+		pcc_r = pcc_cfg.r.r;
+		pcc_g = pcc_cfg.g.g;
+		pcc_b = pcc_cfg.b.b;
+	}
+
+	mutex_unlock(&mlc->lock);
+
+	return scnprintf(buf, PAGE_SIZE, "%d %d %d\n", pcc_r, pcc_g, pcc_b);
+}
+
+/**
+ * simple color temperature interface using polynomial color correction
+ *
+ * input values are r/g/b adjustments from 0-32768 representing 0 -> 1
+ *
+ * example adjustment @ 3500K:
+ * 1.0000 / 0.5515 / 0.2520 = 32768 / 25828 / 17347
+ *
+ * reference chart:
+ * http://www.vendian.org/mncharity/dir3/blackbody/UnstableURLs/bbr_color.html
+ */
+static ssize_t mdss_livedisplay_set_rgb(struct device *dev,
+							struct device_attribute *attr,
+							const char *buf, size_t count)
+{
+	uint32_t r = 0, g = 0, b = 0;
+	struct mdp_pcc_cfg_data pcc_cfg;
+	u32 copyback = 0;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc;
+
+	int ret = -EINVAL;
+
+	if (mfd == NULL)
+		return -ENODEV;
+
+	if (count > 19)
+		return -EINVAL;
+
+	mlc = get_ctx(mfd);
+
+	sscanf(buf, "%d %d %d", &r, &g, &b);
+
+	if (r < 0 || r > 32768)
+		return -EINVAL;
+	if (g < 0 || g > 32768)
+		return -EINVAL;
+	if (b < 0 || b > 32768)
+		return -EINVAL;
+
+	mutex_lock(&mlc->lock);
+	pr_info("%s: r=%d g=%d b=%d", __func__, r, g, b);
+
+	memset(&pcc_cfg, 0, sizeof(struct mdp_pcc_cfg_data));
+
+	pcc_cfg.block = mfd->index + MDP_LOGICAL_BLOCK_DISP_0;
+	if (r == 32768 && g == 32768 && b == 32768)
+		pcc_cfg.ops = MDP_PP_OPS_DISABLE;
+	else
+		pcc_cfg.ops = MDP_PP_OPS_ENABLE;
+	pcc_cfg.ops |= MDP_PP_OPS_WRITE;
+	pcc_cfg.r.r = r;
+	pcc_cfg.g.g = g;
+	pcc_cfg.b.b = b;
+
+	if (mdss_mdp_pcc_config(&pcc_cfg, &copyback) == 0)
+		ret = count;
+
+	mutex_unlock(&mlc->lock);
+
+	return ret;
+}
+
+static DEVICE_ATTR(cabc, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_cabc, mdss_livedisplay_set_cabc);
+//static DEVICE_ATTR(gamma, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_gamma_index, mdss_livedisplay_set_gamma_index);
+static DEVICE_ATTR(sre, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_sre, mdss_livedisplay_set_sre);
+static DEVICE_ATTR(color_enhance, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_color_enhance, mdss_livedisplay_set_color_enhance);
+static DEVICE_ATTR(rgb, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_rgb, mdss_livedisplay_set_rgb);
+
+int mdss_livedisplay_parse_dt(struct device_node *np, struct mdss_panel_info *pinfo)
+{
+	int rc = 0;
+	struct mdss_livedisplay_ctx *mlc;
+
+	if (pinfo == NULL)
+		return -ENODEV;
+
+	mlc = kzalloc(sizeof(struct mdss_livedisplay_ctx), GFP_KERNEL);
+	mutex_init(&mlc->lock);
+
+	rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_off_cmd),
+			"cm,mdss-livedisplay-cabc-off", "qcom,mdss-dsi-off-command-state");
+
+	if (rc == 0) {
+		rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_ui_cmd),
+				"cm,mdss-livedisplay-cabc-ui", "qcom,mdss-dsi-off-command-state");
+		if (rc == 0) {
+			mlc->caps |= MODE_CABC;
+			mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_image_cmd),
+					"cm,mdss-livedisplay-cabc-image", "qcom,mdss-dsi-off-command-state");
+			mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_video_cmd),
+					"cm,mdss-livedisplay-cabc-video", "qcom,mdss-dsi-off-command-state");
+			rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_sre_cmd),
+					"cm,mdss-livedisplay-cabc-sre", "qcom,mdss-dsi-off-command-state");
+			if (rc == 0)
+				mlc->caps |= MODE_SRE;
+		}
+	}
+
+	rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->color_enhance_on_cmd),
+			"cm,mdss-livedisplay-color-enhance-on", "qcom,mdss-dsi-off-command-state");
+
+	if (rc == 0) {
+		rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->color_enhance_off_cmd),
+				"cm,mdss-livedisplay-color-enhance-off", "qcom,mdss-dsi-off-command-state");
+		if (rc == 0)
+			mlc->caps |= MODE_COLOR_ENHANCE;
+	}
+
+    pinfo->livedisplay = mlc;
+	return 0;
+}
+
+int mdss_livedisplay_create_sysfs(struct msm_fb_data_type *mfd)
+{
+	int rc = 0;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	if (mlc == NULL)
+		return 0;
+
+	rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_rgb.attr);
+	if (rc)
+		goto sysfs_err;
+
+	if (mlc->caps & MODE_CABC) {
+		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_cabc.attr);
+		if (rc)
+			goto sysfs_err;
+	}
+
+	if (mlc->caps & MODE_SRE) {
+		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_sre.attr);
+		if (rc)
+			goto sysfs_err;
+	}
+
+	if (mlc->caps & MODE_COLOR_ENHANCE) {
+		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_color_enhance.attr);
+		if (rc)
+			goto sysfs_err;
+	}
+
+	return rc;
+
+sysfs_err:
+	pr_err("%s: sysfs creation failed, rc=%d", __func__, rc);
+	return rc;
+}
+

--- a/drivers/video/msm/mdss/mdss_livedisplay.c
+++ b/drivers/video/msm/mdss/mdss_livedisplay.c
@@ -295,6 +295,11 @@ int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		return -ENODEV;
 
 	mlc = pinfo->livedisplay;
+	if (mlc == NULL)
+		return -ENODEV;
+
+	if (mlc->mfd == NULL)
+		return -ENODEV;
 
 	mutex_lock(&mlc->lock);
 	ret = mdss_livedisplay_update_locked(ctrl_pdata, types);

--- a/drivers/video/msm/mdss/mdss_livedisplay.c
+++ b/drivers/video/msm/mdss/mdss_livedisplay.c
@@ -22,13 +22,111 @@
 #include "mdss_mdp.h"
 #include "mdss_livedisplay.h"
 
+/*
+ * LiveDisplay is the display management service in CyanogenMod. It uses
+ * various capabilities of the hardware and software in order to
+ * optimize the experience for ambient conditions and time of day.
+ *
+ * This module is initialized by mdss_fb for each panel, and creates
+ * several new controls in /sys/class/graphics/fbX based on the
+ * configuration in the devicetree.
+ *
+ * rgb: Always available with MDSS. Used for color temperature and
+ *      user-level calibration. Takes a string of "r g b".
+ *
+ * cabc: Content Adaptive Backlight Control. Must be configured
+ *      in the panel devicetree. Up to three levels.
+ * sre: Sunlight Readability Enhancement. Must be configured in
+ *      the panel devicetree. Up to three levels.
+ * aco: Automatic Contrast Optimization. Must be configured in
+ *      the panel devicetree. Boolean.
+ *
+ * preset: Arbitrary DSI commands, up to 10 may be configured.
+ *      Useful for gamma calibration.
+ *
+ * color_enhance: Hardware color enhancement. Must be configured
+ *      in the panel devicetree. Boolean.
+ */
 
 extern void mdss_dsi_panel_cmds_send(struct mdss_dsi_ctrl_pdata *ctrl,
 		struct dsi_panel_cmds *pcmds);
 
-extern int mdss_dsi_parse_dcs_cmds(struct device_node *np,
-		struct dsi_panel_cmds *pcmds, char *cmd_key, char *link_key);
+static bool is_cabc_cmd(unsigned int value)
+{
+    return (value & MODE_CABC) || (value & MODE_SRE) || (value & MODE_AUTO_CONTRAST);
+}
 
+static int parse_dsi_cmds(struct dsi_panel_cmds *pcmds, const uint8_t *cmd, int blen)
+{
+	int len;
+	char *buf, *bp;
+	struct dsi_ctrl_hdr *dchdr;
+	int i, cnt;
+
+	buf = kzalloc(blen, GFP_KERNEL);
+	if (!buf)
+		return -ENOMEM;
+
+	memcpy(buf, cmd, blen);
+
+	/* scan dcs commands */
+	bp = buf;
+	len = blen;
+	cnt = 0;
+	while (len >= sizeof(*dchdr)) {
+		dchdr = (struct dsi_ctrl_hdr *)bp;
+		dchdr->dlen = ntohs(dchdr->dlen);
+		if (dchdr->dlen > len) {
+			pr_err("%s: dtsi cmd=%x error, len=%d\n",
+				__func__, dchdr->dtype, dchdr->dlen);
+			goto exit_free;
+		}
+		bp += sizeof(*dchdr);
+		len -= sizeof(*dchdr);
+		bp += dchdr->dlen;
+		len -= dchdr->dlen;
+		cnt++;
+	}
+
+	if (len != 0) {
+		pr_err("%s: dcs_cmd=%x len=%d error!\n",
+				__func__, buf[0], blen);
+		goto exit_free;
+	}
+
+	pcmds->cmds = kzalloc(cnt * sizeof(struct dsi_cmd_desc),
+			GFP_KERNEL);
+	if (!pcmds->cmds)
+		goto exit_free;
+
+	pcmds->cmd_cnt = cnt;
+	pcmds->buf = buf;
+	pcmds->blen = blen;
+
+	bp = buf;
+	len = blen;
+	for (i = 0; i < cnt; i++) {
+		dchdr = (struct dsi_ctrl_hdr *)bp;
+		len -= sizeof(*dchdr);
+		bp += sizeof(*dchdr);
+		pcmds->cmds[i].dchdr = *dchdr;
+		pcmds->cmds[i].payload = bp;
+		bp += dchdr->dlen;
+		len -= dchdr->dlen;
+	}
+
+	/*Set default link state to HS Mode*/
+	pcmds->link_state = DSI_HS_MODE;
+
+	pr_debug("%s: dcs_cmd=%x len=%d, cmd_cnt=%d link_state=%d\n", __func__,
+		pcmds->buf[0], pcmds->blen, pcmds->cmd_cnt, pcmds->link_state);
+
+	return 0;
+
+exit_free:
+	kfree(buf);
+	return -ENOMEM;
+}
 
 static int mdss_livedisplay_update_locked(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 		int types)
@@ -36,6 +134,10 @@ static int mdss_livedisplay_update_locked(struct mdss_dsi_ctrl_pdata *ctrl_pdata
 	int ret = 0;
 	struct mdss_panel_info *pinfo = NULL;
 	struct mdss_livedisplay_ctx *mlc = NULL;
+	unsigned int len = 0, dlen = 0;
+	struct dsi_panel_cmds dsi_cmds;
+	uint8_t cabc_value = 0;
+	uint8_t *cmd_buf;
 
 	if (ctrl_pdata == NULL)
 		return -ENODEV;
@@ -51,43 +153,92 @@ static int mdss_livedisplay_update_locked(struct mdss_dsi_ctrl_pdata *ctrl_pdata
 	if (!mlc->caps || !mdss_panel_is_power_on_interactive(pinfo->panel_power_state))
 		return 0;
 
-	if (mlc->caps & MODE_CABC && (types & MODE_CABC || types & MODE_SRE)) {
+	// First find the length of the command array
+	if ((mlc->caps & MODE_PRESET) && (types & MODE_PRESET))
+		len += mlc->presets_len[mlc->preset];
 
-		pr_info("%s: update cabc level=%d  sre=%d\n", __func__,
-				mlc->cabc_mode, mlc->sre_enabled);
+	if ((mlc->caps & MODE_COLOR_ENHANCE) && (types & MODE_COLOR_ENHANCE))
+		len += mlc->ce_enabled ? mlc->ce_on_cmds_len : mlc->ce_off_cmds_len;
 
-		if ((mlc->caps & MODE_SRE) && mlc->sre_enabled) {
-			mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_sre_cmd));
-		} else {
+	if (is_cabc_cmd(types) && is_cabc_cmd(mlc->caps)) {
 
-			switch (mlc->cabc_mode)
-			{
-				case CABC_OFF:
-					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_off_cmd));
-					break;
-				case CABC_UI:
-					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_ui_cmd));
-					break;
-				case CABC_IMAGE:
-					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_image_cmd));
-					break;
-				case CABC_VIDEO:
-					mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->cabc_video_cmd));
-					break;
-				default:
-					pr_err("%s: cabc level %d is not supported!\n",__func__, mlc->cabc_mode);
-					break;
-			}
-		}
+		// The CABC command on most modern panels is also responsible for
+		// other features such as SRE and ACO.  The register fields are bits
+		// and are OR'd together and sent in a single DSI command.
+		if (mlc->cabc_level == CABC_UI)
+			cabc_value |= mlc->cabc_ui_value;
+		else if (mlc->cabc_level == CABC_IMAGE)
+			cabc_value |= mlc->cabc_image_value;
+		else if (mlc->cabc_level == CABC_VIDEO)
+			cabc_value |= mlc->cabc_video_value;
+
+		if (mlc->sre_level == SRE_WEAK)
+			cabc_value |= mlc->sre_weak_value;
+		else if (mlc->sre_level == SRE_MEDIUM)
+			cabc_value |= mlc->sre_medium_value;
+		else if (mlc->sre_level == SRE_STRONG)
+			cabc_value |= mlc->sre_strong_value;
+
+		if (mlc->aco_enabled)
+			cabc_value |= mlc->aco_value;
+
+		len += mlc->cabc_cmds_len;
+
+		pr_info("%s cabc=%d sre=%d aco=%d cmd=%d\n", __func__,
+				mlc->cabc_level, mlc->sre_level, mlc->aco_enabled,
+				cabc_value);
 	}
 
-	if (mlc->caps & MODE_COLOR_ENHANCE && types & MODE_COLOR_ENHANCE) {
+	len += mlc->post_cmds_len;
+
+	if (len == 0)
+		return 0;
+
+	memset(&dsi_cmds, 0, sizeof(struct dsi_panel_cmds));
+	cmd_buf = kzalloc(len + 1, GFP_KERNEL);
+	if (!cmd_buf)
+		return -ENOMEM;
+
+	// Build the command as a single chain, preset first
+	if ((mlc->caps & MODE_PRESET) && (types & MODE_PRESET)) {
+		memcpy(cmd_buf, mlc->presets[mlc->preset], mlc->presets_len[mlc->preset]);
+		dlen += mlc->presets_len[mlc->preset];
+	}
+
+	// Color enhancement
+	if ((mlc->caps & MODE_COLOR_ENHANCE) && (types & MODE_COLOR_ENHANCE)) {
 		if (mlc->ce_enabled) {
-			mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->color_enhance_on_cmd));
+			memcpy(cmd_buf + dlen, mlc->ce_on_cmds, mlc->ce_on_cmds_len);
+			dlen += mlc->ce_on_cmds_len;
 		} else {
-			mdss_dsi_panel_cmds_send(ctrl_pdata, &(mlc->color_enhance_off_cmd));
+			memcpy(cmd_buf + dlen, mlc->ce_off_cmds, mlc->ce_off_cmds_len);
+			dlen += mlc->ce_off_cmds_len;
 		}
 	}
+
+	// CABC/SRE/ACO features
+	if (is_cabc_cmd(types) && mlc->cabc_cmds_len) {
+		memcpy(cmd_buf + dlen, mlc->cabc_cmds, mlc->cabc_cmds_len);
+		dlen += mlc->cabc_cmds_len;
+		// The CABC command parameter is the last value in the sequence
+		cmd_buf[dlen - 1] = cabc_value;
+	}
+
+	// And the post_cmd, can be used to turn on the panel
+	if (mlc->post_cmds_len) {
+		memcpy(cmd_buf + dlen, mlc->post_cmds, mlc->post_cmds_len);
+		dlen += mlc->post_cmds_len;
+	}
+
+	// Parse the command and send it
+	ret = parse_dsi_cmds(&dsi_cmds, (const uint8_t *)cmd_buf, len);
+	if (ret == 0) {
+		mdss_dsi_panel_cmds_send(ctrl_pdata, &dsi_cmds);
+	} else {
+		pr_err("%s: error parsing DSI command! ret=%d", __func__, ret);
+	}
+
+	kfree(cmd_buf);
 
 	return ret;
 }
@@ -128,9 +279,9 @@ static ssize_t mdss_livedisplay_get_cabc(struct device *dev,
 {
 	struct fb_info *fbi = dev_get_drvdata(dev);
 	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
-	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);	
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
 
-	return sprintf(buf, "%d\n", mlc->cabc_mode);
+	return sprintf(buf, "%d\n", mlc->cabc_level);
 }
 
 static ssize_t mdss_livedisplay_set_cabc(struct device *dev,
@@ -146,8 +297,8 @@ static ssize_t mdss_livedisplay_set_cabc(struct device *dev,
 
 	sscanf(buf, "%du", &level);
 	if (level >= CABC_OFF && level < CABC_MAX &&
-				level != mlc->cabc_mode) {
-		mlc->cabc_mode = level;
+				level != mlc->cabc_level) {
+		mlc->cabc_level = level;
 		mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_CABC);
 	}
 
@@ -163,24 +314,24 @@ static ssize_t mdss_livedisplay_get_sre(struct device *dev,
 	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
 	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
 
-	return sprintf(buf, "%d\n", mlc->sre_enabled);
+	return sprintf(buf, "%d\n", mlc->sre_level);
 }
 
 static ssize_t mdss_livedisplay_set_sre(struct device *dev,
 							   struct device_attribute *attr,
 							   const char *buf, size_t count)
 {
-	int value = 0;
+	int level = 0;
 	struct fb_info *fbi = dev_get_drvdata(dev);
 	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
 	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
 
 	mutex_lock(&mlc->lock);
 
-	sscanf(buf, "%du", &value);
-	if ((value == 0 || value == 1)
-			&& value != mlc->sre_enabled) {
-		mlc->sre_enabled = value;
+	sscanf(buf, "%du", &level);
+	if (level >= SRE_OFF && level < SRE_MAX &&
+				level != mlc->sre_level) {
+		mlc->sre_level = level;
 		mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_SRE);
 	}
 
@@ -220,6 +371,82 @@ static ssize_t mdss_livedisplay_set_color_enhance(struct device *dev,
 	mutex_unlock(&mlc->lock);
 
 	return count;
+}
+
+static ssize_t mdss_livedisplay_get_aco(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	return sprintf(buf, "%d\n", mlc->aco_enabled);
+}
+
+static ssize_t mdss_livedisplay_set_aco(struct device *dev,
+							   struct device_attribute *attr,
+							   const char *buf, size_t count)
+{
+	int value = 0;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	mutex_lock(&mlc->lock);
+
+	sscanf(buf, "%du", &value);
+	if ((value == 0 || value == 1)
+			&& value != mlc->aco_enabled) {
+		mlc->aco_enabled = value;
+		mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_AUTO_CONTRAST);
+	}
+
+	mutex_unlock(&mlc->lock);
+
+	return count;
+}
+
+static ssize_t mdss_livedisplay_get_preset(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	return sprintf(buf, "%d\n", mlc->preset);
+}
+
+static ssize_t mdss_livedisplay_set_preset(struct device *dev,
+							   struct device_attribute *attr,
+							   const char *buf, size_t count)
+{
+	int value = 0;
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	mutex_lock(&mlc->lock);
+
+	sscanf(buf, "%du", &value);
+	if (value < 0 || value >= mlc->num_presets)
+		return -EINVAL;
+
+	mlc->preset = value;
+	mdss_livedisplay_update_locked(get_ctrl(mfd), MODE_PRESET);
+
+	mutex_unlock(&mlc->lock);
+
+	return count;
+}
+
+static ssize_t mdss_livedisplay_get_num_presets(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct fb_info *fbi = dev_get_drvdata(dev);
+	struct msm_fb_data_type *mfd = (struct msm_fb_data_type *)fbi->par;
+	struct mdss_livedisplay_ctx *mlc = get_ctx(mfd);
+
+	return sprintf(buf, "%d\n", mlc->num_presets);
 }
 
 static ssize_t mdss_livedisplay_get_rgb(struct device *dev,
@@ -301,7 +528,7 @@ static ssize_t mdss_livedisplay_set_rgb(struct device *dev,
 		return -EINVAL;
 
 	mutex_lock(&mlc->lock);
-	pr_info("%s: r=%d g=%d b=%d", __func__, r, g, b);
+	pr_info("%s: r=%d g=%d b=%d\n", __func__, r, g, b);
 
 	memset(&pcc_cfg, 0, sizeof(struct mdp_pcc_cfg_data));
 
@@ -324,15 +551,19 @@ static ssize_t mdss_livedisplay_set_rgb(struct device *dev,
 }
 
 static DEVICE_ATTR(cabc, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_cabc, mdss_livedisplay_set_cabc);
-//static DEVICE_ATTR(gamma, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_gamma_index, mdss_livedisplay_set_gamma_index);
 static DEVICE_ATTR(sre, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_sre, mdss_livedisplay_set_sre);
 static DEVICE_ATTR(color_enhance, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_color_enhance, mdss_livedisplay_set_color_enhance);
+static DEVICE_ATTR(aco, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_aco, mdss_livedisplay_set_aco);
+static DEVICE_ATTR(preset, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_preset, mdss_livedisplay_set_preset);
+static DEVICE_ATTR(num_presets, S_IRUGO, mdss_livedisplay_get_num_presets, NULL);
 static DEVICE_ATTR(rgb, S_IRUGO | S_IWUSR | S_IWGRP, mdss_livedisplay_get_rgb, mdss_livedisplay_set_rgb);
 
 int mdss_livedisplay_parse_dt(struct device_node *np, struct mdss_panel_info *pinfo)
 {
-	int rc = 0;
+	int rc = 0, i = 0;
 	struct mdss_livedisplay_ctx *mlc;
+	char preset_name[64];
+	uint32_t tmp = 0;
 
 	if (pinfo == NULL)
 		return -ENODEV;
@@ -340,36 +571,60 @@ int mdss_livedisplay_parse_dt(struct device_node *np, struct mdss_panel_info *pi
 	mlc = kzalloc(sizeof(struct mdss_livedisplay_ctx), GFP_KERNEL);
 	mutex_init(&mlc->lock);
 
-	rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_off_cmd),
-			"cm,mdss-livedisplay-cabc-off", "qcom,mdss-dsi-off-command-state");
+	mlc->cabc_cmds = of_get_property(np,
+			"cm,mdss-livedisplay-cabc-cmd", &mlc->cabc_cmds_len);
 
-	if (rc == 0) {
-		rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_ui_cmd),
-				"cm,mdss-livedisplay-cabc-ui", "qcom,mdss-dsi-off-command-state");
+	if (mlc->cabc_cmds_len > 0) {
+		rc = of_property_read_u32(np, "cm,mdss-livedisplay-cabc-ui-value", &tmp);
 		if (rc == 0) {
 			mlc->caps |= MODE_CABC;
-			mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_image_cmd),
-					"cm,mdss-livedisplay-cabc-image", "qcom,mdss-dsi-off-command-state");
-			mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_video_cmd),
-					"cm,mdss-livedisplay-cabc-video", "qcom,mdss-dsi-off-command-state");
-			rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->cabc_sre_cmd),
-					"cm,mdss-livedisplay-cabc-sre", "qcom,mdss-dsi-off-command-state");
-			if (rc == 0)
-				mlc->caps |= MODE_SRE;
+			mlc->cabc_ui_value = (uint8_t)(tmp & 0xFF);
+			of_property_read_u32(np, "cm,mdss-livedisplay-cabc-image-value", &tmp);
+			mlc->cabc_image_value = (uint8_t)(tmp & 0xFF);
+			of_property_read_u32(np, "cm,mdss-livedisplay-cabc-video-value", &tmp);
+			mlc->cabc_video_value = (uint8_t)(tmp & 0xFF);
+		}
+		rc = of_property_read_u32(np, "cm,mdss-livedisplay-sre-medium-value", &tmp);
+		if (rc == 0) {
+			mlc->caps |= MODE_SRE;
+			mlc->sre_medium_value = (uint8_t)(tmp & 0xFF);
+			of_property_read_u32(np, "cm,mdss-livedisplay-sre-weak-value", &tmp);
+			mlc->sre_weak_value = (uint8_t)(tmp & 0xFF);
+			of_property_read_u32(np, "cm,mdss-livedisplay-sre-strong-value", &tmp);
+			mlc->sre_strong_value = (uint8_t)(tmp & 0xFF);
+		}
+		rc = of_property_read_u32(np, "cm,mdss-livedisplay-aco-value", &tmp);
+		if (rc == 0) {
+			mlc->caps |= MODE_AUTO_CONTRAST;
+			mlc->aco_value = (uint8_t)(tmp & 0xFF);
 		}
 	}
 
-	rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->color_enhance_on_cmd),
-			"cm,mdss-livedisplay-color-enhance-on", "qcom,mdss-dsi-off-command-state");
-
-	if (rc == 0) {
-		rc = mdss_dsi_parse_dcs_cmds(np, &(mlc->color_enhance_off_cmd),
-				"cm,mdss-livedisplay-color-enhance-off", "qcom,mdss-dsi-off-command-state");
-		if (rc == 0)
+	mlc->ce_on_cmds = of_get_property(np,
+			"cm,mdss-livedisplay-color-enhance-on", &mlc->ce_on_cmds_len);
+	if (mlc->ce_on_cmds_len) {
+		mlc->ce_off_cmds = of_get_property(np,
+				"cm,mdss-livedisplay-color-enhance-off", &mlc->ce_off_cmds_len);
+		if (mlc->ce_off_cmds_len)
 			mlc->caps |= MODE_COLOR_ENHANCE;
 	}
 
-    pinfo->livedisplay = mlc;
+	for (i = 0; i < MAX_PRESETS; i++) {
+		memset(preset_name, 0, sizeof(preset_name));
+		snprintf(preset_name, 64, "%s-%d", "cm,mdss-livedisplay-preset", i);
+		mlc->presets[mlc->num_presets] = of_get_property(np, preset_name,
+				&mlc->presets_len[mlc->num_presets]);
+		if (mlc->presets_len[mlc->num_presets] > 0)
+			mlc->num_presets++;
+	}
+
+	if (mlc->num_presets)
+		mlc->caps |= MODE_PRESET;
+
+	mlc->post_cmds = of_get_property(np,
+			"cm,mdss-livedisplay-post-cmd", &mlc->post_cmds_len);
+
+	pinfo->livedisplay = mlc;
 	return 0;
 }
 
@@ -397,8 +652,23 @@ int mdss_livedisplay_create_sysfs(struct msm_fb_data_type *mfd)
 			goto sysfs_err;
 	}
 
+	if (mlc->caps & MODE_AUTO_CONTRAST) {
+		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_aco.attr);
+		if (rc)
+			goto sysfs_err;
+	}
+
 	if (mlc->caps & MODE_COLOR_ENHANCE) {
 		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_color_enhance.attr);
+		if (rc)
+			goto sysfs_err;
+	}
+
+	if (mlc->caps & MODE_PRESET) {
+		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_preset.attr);
+		if (rc)
+			goto sysfs_err;
+		rc = sysfs_create_file(&mfd->fbi->dev->kobj, &dev_attr_num_presets.attr);
 		if (rc)
 			goto sysfs_err;
 	}

--- a/drivers/video/msm/mdss/mdss_livedisplay.h
+++ b/drivers/video/msm/mdss/mdss_livedisplay.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015 The CyanogenMod Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef MDSS_LIVEDISPLAY_H
+#define MDSS_LIVEDISPLAY_H
+
+#include <linux/of.h>
+#include <linux/sysfs.h>
+
+#include "mdss_dsi.h"
+
+struct mdss_livedisplay_ctx {
+	struct dsi_panel_cmds cabc_off_cmd;
+	struct dsi_panel_cmds cabc_ui_cmd;
+	struct dsi_panel_cmds cabc_image_cmd;
+	struct dsi_panel_cmds cabc_video_cmd;
+	struct dsi_panel_cmds cabc_sre_cmd;
+	struct dsi_panel_cmds color_enhance_on_cmd;
+	struct dsi_panel_cmds color_enhance_off_cmd;
+
+	unsigned int cabc_mode;
+	bool sre_enabled;
+	bool ce_enabled;
+
+	unsigned int caps;
+
+	struct mutex lock;
+};
+
+enum {
+	CABC_OFF,
+	CABC_UI,
+	CABC_IMAGE,
+	CABC_VIDEO,
+	CABC_MAX
+};
+
+enum {
+	MODE_CABC = 1,
+	MODE_SRE = 2,
+	MODE_COLOR_ENHANCE = 4,
+    MODE_UPDATE_ALL = MODE_CABC | MODE_SRE | MODE_COLOR_ENHANCE,
+};
+
+int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int types);
+int mdss_livedisplay_parse_dt(struct device_node *np, struct mdss_panel_info *pinfo);
+int mdss_livedisplay_create_sysfs(struct msm_fb_data_type *mfd);
+
+#endif

--- a/drivers/video/msm/mdss/mdss_livedisplay.h
+++ b/drivers/video/msm/mdss/mdss_livedisplay.h
@@ -18,6 +18,7 @@
 #include <linux/sysfs.h>
 
 #include "mdss_dsi.h"
+#include "mdss_fb.h"
 
 #define MAX_PRESETS 10
 
@@ -53,6 +54,9 @@ struct mdss_livedisplay_ctx {
 	unsigned int num_presets;
 	unsigned int caps;
 
+	uint32_t r, g, b;
+	struct msm_fb_data_type *mfd;
+
 	struct mutex lock;
 };
 
@@ -84,5 +88,21 @@ enum {
 int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int types);
 int mdss_livedisplay_parse_dt(struct device_node *np, struct mdss_panel_info *pinfo);
 int mdss_livedisplay_create_sysfs(struct msm_fb_data_type *mfd);
+
+static inline bool is_cabc_cmd(unsigned int value)
+{
+    return (value & MODE_CABC) || (value & MODE_SRE) || (value & MODE_AUTO_CONTRAST);
+}
+
+static inline struct mdss_livedisplay_ctx* get_ctx(struct msm_fb_data_type *mfd)
+{
+    return mfd->panel_info->livedisplay;
+}
+
+static inline struct mdss_dsi_ctrl_pdata* get_ctrl(struct msm_fb_data_type *mfd)
+{
+    struct mdss_panel_data *pdata = dev_get_platdata(&mfd->pdev->dev);
+    return container_of(pdata, struct mdss_dsi_ctrl_pdata, panel_data);
+}
 
 #endif

--- a/drivers/video/msm/mdss/mdss_livedisplay.h
+++ b/drivers/video/msm/mdss/mdss_livedisplay.h
@@ -19,19 +19,38 @@
 
 #include "mdss_dsi.h"
 
-struct mdss_livedisplay_ctx {
-	struct dsi_panel_cmds cabc_off_cmd;
-	struct dsi_panel_cmds cabc_ui_cmd;
-	struct dsi_panel_cmds cabc_image_cmd;
-	struct dsi_panel_cmds cabc_video_cmd;
-	struct dsi_panel_cmds cabc_sre_cmd;
-	struct dsi_panel_cmds color_enhance_on_cmd;
-	struct dsi_panel_cmds color_enhance_off_cmd;
+#define MAX_PRESETS 10
 
-	unsigned int cabc_mode;
-	bool sre_enabled;
+struct mdss_livedisplay_ctx {
+	uint8_t cabc_ui_value;
+	uint8_t cabc_image_value;
+	uint8_t cabc_video_value;
+	uint8_t sre_weak_value;
+	uint8_t sre_medium_value;
+	uint8_t sre_strong_value;
+	uint8_t aco_value;
+
+	const uint8_t *ce_off_cmds;
+	const uint8_t *ce_on_cmds;
+	unsigned int ce_off_cmds_len;
+	unsigned int ce_on_cmds_len;
+
+	const uint8_t *presets[MAX_PRESETS];
+	unsigned int presets_len[MAX_PRESETS];
+
+	const uint8_t *cabc_cmds;
+	unsigned int cabc_cmds_len;
+
+	const uint8_t *post_cmds;
+	unsigned int post_cmds_len;
+
+	unsigned int preset;
+	unsigned int cabc_level;
+	unsigned int sre_level;
+	bool aco_enabled;
 	bool ce_enabled;
 
+	unsigned int num_presets;
 	unsigned int caps;
 
 	struct mutex lock;
@@ -46,10 +65,20 @@ enum {
 };
 
 enum {
-	MODE_CABC = 1,
-	MODE_SRE = 2,
-	MODE_COLOR_ENHANCE = 4,
-    MODE_UPDATE_ALL = MODE_CABC | MODE_SRE | MODE_COLOR_ENHANCE,
+	SRE_OFF,
+	SRE_WEAK,
+	SRE_MEDIUM,
+	SRE_STRONG,
+	SRE_MAX
+};
+
+enum {
+	MODE_CABC		= 0x01,
+	MODE_SRE		= 0x02,
+	MODE_AUTO_CONTRAST	= 0x04,
+	MODE_COLOR_ENHANCE	= 0x08,
+	MODE_PRESET		= 0x10,
+	MODE_UPDATE_ALL		= 0xFF,
 };
 
 int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata, int types);

--- a/drivers/video/msm/mdss/mdss_mdp.h
+++ b/drivers/video/msm/mdss/mdss_mdp.h
@@ -1196,5 +1196,6 @@ int mdss_mdp_cmd_set_autorefresh_mode(struct mdss_mdp_ctl *ctl,
 		int frame_cnt);
 int mdss_mdp_ctl_cmd_autorefresh_enable(struct mdss_mdp_ctl *ctl,
 		int frame_cnt);
+int mdss_mdp_user_pcc_config(struct mdp_pcc_cfg_data *config);
 
 #endif /* MDSS_MDP_H */

--- a/drivers/video/msm/mdss/mdss_mdp_pp.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pp.c
@@ -3001,6 +3001,8 @@ static void pp_update_pcc_regs(char __iomem *addr,
 
 static u32 pcc_rescale(u32 raw, u32 user)
 {
+	int val = 0;
+
 	if (raw == 0 && user == 0)
 		return 0;
 	else if (raw == 0)
@@ -3008,9 +3010,8 @@ static u32 pcc_rescale(u32 raw, u32 user)
 	else if (user == 0)
 		return raw;
 
-	// no floats
-
-	return (u32)((((u64)raw << 15) * (u64)user) >> 30);
+	val = 32768 - ((32768 - raw) + (32768 - user));
+	return val < 100 ? 100 : val;
 }
 
 static void pcc_combine(struct mdp_pcc_cfg_data *raw,

--- a/drivers/video/msm/mdss/mdss_mdp_pp.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pp.c
@@ -3003,9 +3003,9 @@ static u32 pcc_rescale(u32 raw, u32 user)
 {
 	int val = 0;
 
-	if (raw == 0 || raw > 32768)
+	if (raw > 32768)
 		raw = 32768;
-	if (user == 0 || user > 32768)
+	if (user > 32768)
 		user = 32768;
 	val = 32768 - ((32768 - raw) + (32768 - user));
 	return val < 100 ? 100 : val;
@@ -3035,10 +3035,15 @@ static void pcc_combine(struct mdp_pcc_cfg_data *raw,
 	// there is a mode switch. we only care about the base
 	// coefficients from the user config.
 
+	if (!r_en || (raw->r.r == 0 && raw->g.g == 0 && raw->b.b == 0))
+		raw->r.r = raw->g.g = raw->b.b = 32768;
+	if (!u_en || (user->r.r == 0 && user->g.g == 0 && user->b.b ==0))
+		user->r.r = user->g.g = user->b.b = 32768;
+
 	memcpy(real, raw, sizeof(struct mdp_pcc_cfg_data));
-	real->r.r = pcc_rescale((r_en ? raw->r.r : 0), (u_en ? user->r.r : 0));
-	real->g.g = pcc_rescale((r_en ? raw->g.g : 0), (u_en ? user->g.g : 0));
-	real->b.b = pcc_rescale((r_en ? raw->b.b : 0), (u_en ? user->b.b : 0));
+	real->r.r = pcc_rescale(raw->r.r, user->r.r);
+	real->g.g = pcc_rescale(raw->g.g, user->g.g);
+	real->b.b = pcc_rescale(raw->b.b, user->b.b);
 	if (r_en && u_en)
 		real->ops = r_ops | u_ops;
 	else if (r_en)

--- a/drivers/video/msm/mdss/mdss_mdp_pp.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pp.c
@@ -3003,13 +3003,10 @@ static u32 pcc_rescale(u32 raw, u32 user)
 {
 	int val = 0;
 
-	if (raw == 0 && user == 0)
-		return 0;
-	else if (raw == 0)
-		return user;
-	else if (user == 0)
-		return raw;
-
+	if (raw == 0 || raw > 32768)
+		raw = 32768;
+	if (user == 0 || user > 32768)
+		user = 32768;
 	val = 32768 - ((32768 - raw) + (32768 - user));
 	return val < 100 ? 100 : val;
 }

--- a/drivers/video/msm/mdss/mdss_mdp_pp.c
+++ b/drivers/video/msm/mdss/mdss_mdp_pp.c
@@ -437,6 +437,8 @@ struct mdss_pp_res_type {
 	struct pp_sts_type pp_disp_sts[MDSS_MAX_MIXER_DISP_NUM];
 	/* physical info */
 	struct pp_hist_col_info *dspp_hist;
+	struct mdp_pcc_cfg_data raw_pcc_disp_cfg[MDSS_BLOCK_DISP_NUM];
+	struct mdp_pcc_cfg_data user_pcc_disp_cfg[MDSS_BLOCK_DISP_NUM];
 };
 
 static DEFINE_MUTEX(mdss_pp_mutex);
@@ -2997,6 +2999,98 @@ static void pp_update_pcc_regs(char __iomem *addr,
 	writel_relaxed(cfg_ptr->b.rgb_1, addr + 8);
 }
 
+static u32 pcc_rescale(u32 raw, u32 user)
+{
+	if (raw == 0 && user == 0)
+		return 0;
+	else if (raw == 0)
+		return user;
+	else if (user == 0)
+		return raw;
+
+	// no floats
+
+	return (u32)((((u64)raw << 15) * (u64)user) >> 30);
+}
+
+static void pcc_combine(struct mdp_pcc_cfg_data *raw,
+		struct mdp_pcc_cfg_data *user,
+		struct mdp_pcc_cfg_data *real)
+{
+	uint32_t r_ops, u_ops, r_en, u_en;
+
+	if (real == NULL) {
+		real = kzalloc(sizeof(struct mdp_pcc_cfg_data), GFP_KERNEL);
+		if (!real) {
+			pr_err("%s: alloc failed!", __func__);
+			return;
+		}
+	}
+
+	r_ops = raw ? raw->ops : MDP_PP_OPS_DISABLE;
+	u_ops = user ? user->ops : MDP_PP_OPS_DISABLE;
+	r_en = raw && !(raw->ops & MDP_PP_OPS_DISABLE);
+	u_en = user && !(user->ops & MDP_PP_OPS_DISABLE);
+
+	// user configuration may change often, but the raw configuration
+	// will correspond to calibration data which should only change if
+	// there is a mode switch. we only care about the base
+	// coefficients from the user config.
+
+	memcpy(real, raw, sizeof(struct mdp_pcc_cfg_data));
+	real->r.r = pcc_rescale((r_en ? raw->r.r : 0), (u_en ? user->r.r : 0));
+	real->g.g = pcc_rescale((r_en ? raw->g.g : 0), (u_en ? user->g.g : 0));
+	real->b.b = pcc_rescale((r_en ? raw->b.b : 0), (u_en ? user->b.b : 0));
+	if (r_en && u_en)
+		real->ops = r_ops | u_ops;
+	else if (r_en)
+		real->ops = r_ops;
+	else if (u_en)
+		real->ops = u_ops;
+	else
+		real->ops = MDP_PP_OPS_DISABLE;
+
+	pr_debug("%s: raw:\n", __func__);
+	pp_print_pcc_cfg_data(raw, 0);
+	pr_debug("%s: user:\n", __func__);
+	pp_print_pcc_cfg_data(user, 0);
+	pr_debug("%s: real:\n", __func__);
+	pp_print_pcc_cfg_data(real, 0);
+}
+
+int mdss_mdp_user_pcc_config(struct mdp_pcc_cfg_data *config)
+{
+	int ret = 0;
+	u32 disp_num = 0;
+
+	if ((config->block < MDP_LOGICAL_BLOCK_DISP_0) ||
+		(config->block >= MDP_BLOCK_MAX))
+		return -EINVAL;
+
+	if ((config->ops & MDSS_PP_SPLIT_MASK) == MDSS_PP_SPLIT_MASK) {
+		pr_warn("Can't set both split bits\n");
+		return -EINVAL;
+	}
+
+	if (config->ops & MDP_PP_OPS_READ) {
+		pr_warn("Only write is supported for user PCC\n");
+		return -EINVAL;
+	}
+
+	mutex_lock(&mdss_pp_mutex);
+	disp_num = config->block - MDP_LOGICAL_BLOCK_DISP_0;
+
+	mdss_pp_res->user_pcc_disp_cfg[disp_num] = *config;
+	pcc_combine(&mdss_pp_res->raw_pcc_disp_cfg[disp_num],
+				&mdss_pp_res->user_pcc_disp_cfg[disp_num],
+				&mdss_pp_res->pcc_disp_cfg[disp_num]);
+	mdss_pp_res->pp_disp_flags[disp_num] |= PP_FLAGS_DIRTY_PCC;
+
+	mutex_unlock(&mdss_pp_mutex);
+	return ret;
+}
+
+
 int mdss_mdp_pcc_config(struct mdp_pcc_cfg_data *config,
 					u32 *copyback)
 {
@@ -3032,7 +3126,10 @@ int mdss_mdp_pcc_config(struct mdp_pcc_cfg_data *config,
 		*copyback = 1;
 		mdss_mdp_clk_ctrl(MDP_BLOCK_POWER_OFF);
 	} else {
-		mdss_pp_res->pcc_disp_cfg[disp_num] = *config;
+		mdss_pp_res->raw_pcc_disp_cfg[disp_num] = *config;
+		pcc_combine(&mdss_pp_res->raw_pcc_disp_cfg[disp_num],
+					&mdss_pp_res->user_pcc_disp_cfg[disp_num],
+					&mdss_pp_res->pcc_disp_cfg[disp_num]);
 		mdss_pp_res->pp_disp_flags[disp_num] |= PP_FLAGS_DIRTY_PCC;
 		if (config->ops & MDP_PP_OPS_DEFER_ENABLE) {
 			mdss_pp_res->pp_disp_flags[disp_num] &=

--- a/drivers/video/msm/mdss/mdss_panel.h
+++ b/drivers/video/msm/mdss/mdss_panel.h
@@ -508,6 +508,8 @@ struct mdss_mdp_pp_tear_check {
 	u32 refx100;
 };
 
+struct mdss_livedisplay_ctx;
+
 struct mdss_panel_info {
 	u32 xres;
 	u32 yres;
@@ -590,6 +592,9 @@ struct mdss_panel_info {
 	struct edp_panel_info edp;
 
 	bool is_dba_panel;
+
+	struct mdss_livedisplay_ctx *livedisplay;
+
 	/* debugfs structure for the panel */
 	struct mdss_panel_debugfs_info *debugfs_info;
 };


### PR DESCRIPTION
Add live display patches which are used by live display hal @ Lineage.
~~https://github.com/LineageOS/android_hardware_lineage_interfaces/blob/lineage-15.1/livedisplay/1.0/default/impl/SDM.cpp~~
but
[DisplayColorCalibration](https://github.com/LineageOS/android_hardware_lineage_lineagehw/blob/76982bfcba9e6ced27437ef2c1e8281fbc0bb3b0/src/org/lineageos/hardware/DisplayColorCalibration.java#L37)

The origin of these patches where taken from
https://github.com/LineageOS/android_kernel_lge_msm8952.git

I was told from the Lineage people (rashed) to use this.