### PR TITLE
prima: Adapt WLAN_MSG_WLAN_TP_IND netlink message.

### DIFF
--- a/drivers/staging/prima/CORE/HDD/inc/wlan_hdd_main.h
+++ b/drivers/staging/prima/CORE/HDD/inc/wlan_hdd_main.h
@@ -1863,12 +1863,6 @@ struct hdd_context_s
     struct mutex cache_channel_lock;
 };
 
-typedef enum  {
-        TP_IND_LOW = 1,
-        TP_IND_MEDIUM,
-        TP_IND_HIGH,
-}TP_IND_TYPE;
-
 /* Use to notify the TDLS or BTCOEX is mode enable */
 typedef enum
 {

--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_main.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_main.c
@@ -12853,13 +12853,13 @@ void hdd_request_tcp_delack(hdd_context_t *pHddCtx, uint64_t rx_packets)
     /* average of rx_packets and prev_rx is taken so that
        bus width doesnot fluctuate much */
     uint64_t temp_rx = (rx_packets + pHddCtx->prev_rx)/2;
-    TP_IND_TYPE next_rx_level = pHddCtx->cur_rx_level;
+    enum wlan_tp_level next_rx_level = pHddCtx->cur_rx_level;
 
     pHddCtx->prev_rx = rx_packets;
     if (temp_rx > pHddCtx->cfg_ini->tcpDelAckThresholdHigh)
-        next_rx_level = TP_IND_HIGH;
+        next_rx_level = WLAN_SVC_TP_HIGH;
     else if (temp_rx <= pHddCtx->cfg_ini->tcpDelAckThresholdLow)
-        next_rx_level = TP_IND_LOW;
+        next_rx_level = WLAN_SVC_TP_LOW;
 
     hdd_set_delack_value(pHddCtx, next_rx_level);
 }
@@ -15487,6 +15487,7 @@ v_U8_t  hdd_get_total_sessions(hdd_context_t *pHddCtx)
  */
 void hdd_set_delack_value(hdd_context_t *pHddCtx, v_U32_t next_rx_level)
 {
+    struct wlan_rx_tp_data rx_tp_data = {0};
     if (pHddCtx->cur_rx_level != next_rx_level) {
         VOS_TRACE(VOS_MODULE_ID_HDD, VOS_TRACE_LEVEL_DEBUG,
                "%s: TCP DELACK trigger level %d",
@@ -15494,8 +15495,22 @@ void hdd_set_delack_value(hdd_context_t *pHddCtx, v_U32_t next_rx_level)
         mutex_lock(&pHddCtx->cur_rx_level_lock);
         pHddCtx->cur_rx_level = next_rx_level;
         mutex_unlock(&pHddCtx->cur_rx_level_lock);
-        wlan_hdd_send_svc_nlink_msg(WLAN_SVC_WLAN_TP_IND, &next_rx_level,
-                                                       sizeof(next_rx_level));
+	/* Send throughput indication only if it is enabled.
+	 * Disabling tcp_del_ack will revert the tcp stack behavior
+	 * to default delayed ack. Note that this will disable the
+	 * dynamic delayed ack mechanism across the system
+	 */
+	if (&pHddCtx->cfg_ini->enable_delack)
+	    rx_tp_data.rx_tp_flags |= TCP_DEL_ACK_IND;
+
+//  There's no support for config option enable_tcp_adv_win_scale.
+//  Use the old behavior which enables this option
+//	if (&pHddCtx->config->enable_tcp_adv_win_scale)
+	    rx_tp_data.rx_tp_flags |= TCP_ADV_WIN_SCL;
+
+	rx_tp_data.level = next_rx_level;
+        wlan_hdd_send_svc_nlink_msg(WLAN_SVC_WLAN_TP_IND, &rx_tp_data,
+                                                       sizeof(rx_tp_data));
     }
 }
 
@@ -15518,7 +15533,7 @@ void hdd_set_default_stop_delack_timer(hdd_context_t *pHddCtx)
     }
 
     vos_timer_stop(&pHddCtx->delack_timer);
-    hdd_set_delack_value(pHddCtx, TP_IND_LOW);
+    hdd_set_delack_value(pHddCtx, WLAN_SVC_TP_LOW);
 }
 
 /**

--- a/drivers/staging/prima/CORE/SVC/external/wlan_nlink_common.h
+++ b/drivers/staging/prima/CORE/SVC/external/wlan_nlink_common.h
@@ -123,4 +123,40 @@ typedef struct sAniHdr {
    unsigned short length;
 } tAniHdr, tAniMsgHdr;
 
+/**
+ * enum wlan_tp_level - indicates wlan throughput level
+ * @WLAN_SVC_TP_NONE:	 used for initialization
+ * @WLAN_SVC_TP_LOW:	 used to identify low throughput level
+ * @WLAN_SVC_TP_MEDIUM:	 used to identify medium throughput level
+ * @WLAN_SVC_TP_HIGH:	 used to identify high throughput level
+ *
+ * The different throughput levels are determined on the basis of # of tx and
+ * rx packets and other threshold values. For example, if the # of total
+ * packets sent or received by the driver is greater than 500 in the last 100ms
+ * , the driver has a high throughput requirement. The driver may tweak certain
+ * system parameters based on the throughput level.
+ */
+enum wlan_tp_level {
+    WLAN_SVC_TP_NONE,
+    WLAN_SVC_TP_LOW,
+    WLAN_SVC_TP_MEDIUM,
+    WLAN_SVC_TP_HIGH,
+};
+
+/* Indication to enable TCP delayed ack in TPUT indication */
+#define TCP_DEL_ACK_IND	(1 << 0)
+/* Indication to enable TCP advance window scaling in TPUT indication */
+#define TCP_ADV_WIN_SCL	(1 << 1)
+
+/**
+  * struct wlan_rx_tp_data - msg to TCP delayed ack and advance window scaling
+  * @level:            Throughput level.
+  * @rx_tp_flags:      Bit map of flags, for which this indcation will take
+  *                    effect, bit map for TCP_ADV_WIN_SCL and TCP_DEL_ACK_IND.
+  */
+struct wlan_rx_tp_data {
+	enum wlan_tp_level level;
+    uint16_t rx_tp_flags;
+};
+
 #endif //WLAN_NLINK_COMMON_H__


### PR DESCRIPTION
In old prima drivers, the WLAN_MSG_WLAN_TP_IND hint
is sent as an simple integer value, which defines the throughput level.
In newer prima drivers ( qcacld-3.0 ) this is extended by an flag,
where the enable_tcp_delack and enable_tcp_adv_win_scale parameters
can be added.
This is hint is processed by the cnss-daemon which adjusts then
tcp kernel values according these hints.

Newer cnss-daemons expect this structure and not a simple integer.
This patch uses the structures from qcacld-3.0 and applies them for the
prima driver which should be used in conjunction with newer cnss-daemons.