### PR TITLE
Fix lpm parameters

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-pm.dtsi
@@ -254,7 +254,7 @@
 						qcom,latency-us = <31>;
 						qcom,ss-power = <552>;
 						qcom,energy-overhead = <64172>;
-						qcom,time-overhead = <61>;
+						qcom,time-overhead = <81>;
 					};
 
 					qcom,pm-cpu-level@1 {
@@ -262,9 +262,9 @@
 						qcom,psci-cpu-mode = <2>;
 						qcom,spm-cpu-mode = "retention";
 						qcom,latency-us = <99>;
-						qcom,ss-power = <545>;
+						qcom,ss-power = <540>;
 						qcom,energy-overhead = <150122>;
-						qcom,time-overhead = <239>;
+						qcom,time-overhead = <241>;
 						qcom,use-broadcast-timer;
 					};
 

--- a/drivers/cpuidle/lpm-levels-of.c
+++ b/drivers/cpuidle/lpm-levels-of.c
@@ -730,7 +730,7 @@ static int calculate_residency(struct power_params *base_pwr,
 	residency /= (int32_t)(base_pwr->ss_power  - next_pwr->ss_power);
 
 	if (residency < 0) {
-		__WARN_printf("%s: Incorrect power attributes for LPM\n",
+		pr_err("%s: residency < 0 for LPM\n",
 				__func__);
 		return 0;
 	}


### PR DESCRIPTION
At boot there is an warning about the initialization of the "Low Power Management Levels".
[    1.580922] ------------[ cut here ]------------
[    1.580930] WARNING: at ../../../../../../kernel/lenovo/msm8976/drivers/cpuidle/lpm-levels-of.c:734 parse_cluster+0x950/0xdc8()
[    1.580931] calculate_residency: Incorrect power attributes for LPM
[    1.580935] CPU: 5 PID: 1 Comm: swapper/0 Tainted: G        W    3.10.108_LA.BR.1.3.7_rb1.11-g9fbe595b3928-13112-g09808041635e #11
[    1.580937] Call trace:
[    1.580942] [<ffffffc000087d84>] dump_backtrace+0x0/0x26c
[    1.580945] [<ffffffc000088004>] show_stack+0x14/0x1c
[    1.580948] [<ffffffc000ce6958>] dump_stack+0x20/0x28
[    1.580952] [<ffffffc00009e37c>] warn_slowpath_common+0x74/0x9c
[    1.580954] [<ffffffc00009e420>] warn_slowpath_fmt+0x50/0x58
[    1.580956] [<ffffffc0007248d0>] parse_cluster+0x950/0xdc8
[    1.580958] [<ffffffc0007243fc>] parse_cluster+0x47c/0xdc8
[    1.580959] [<ffffffc000724dc8>] lpm_of_parse_cluster+0x80/0xa8
[    1.580961] [<ffffffc000720a90>] lpm_probe+0x2c/0x260
[    1.580966] [<ffffffc00047c768>] platform_drv_probe+0x18/0x20
[    1.580968] [<ffffffc00047b23c>] driver_probe_device+0x160/0x374
[    1.580970] [<ffffffc00047b500>] __driver_attach+0x64/0x90
[    1.580972] [<ffffffc0004796d8>] bus_for_each_dev+0x74/0x90
[    1.580974] [<ffffffc00047b074>] driver_attach+0x20/0x28
[    1.580976] [<ffffffc000479f98>] bus_add_driver+0x114/0x234
[    1.580978] [<ffffffc00047bd44>] driver_register+0x94/0x110
[    1.580980] [<ffffffc00047d0d4>] platform_driver_register+0x5c/0x64
[    1.580984] [<ffffffc00134dc50>] lpm_levels_module_init+0x1c/0x44
[    1.580987] [<ffffffc00131586c>] do_one_initcall+0xb4/0x158
[    1.580989] [<ffffffc001315a58>] kernel_init_freeable+0x148/0x1e8
[    1.580993] [<ffffffc000cdcaec>] kernel_init+0x14/0xcc
[    1.580994] ---[ end trace da227214a82491c2 ]---

It complains, because the calculated residency is lower than 0.

The approach is to use valid values which are updated by the sony developers for our soc (although they are using 8956 which doesn't matter here in my opinion).
https://github.com/Lenovo-YTX703-Devel/android_kernel_lenovo_msm8976/commit/3961c9808c6fd3174fa3fa3eb485799e399bf86b

Comparing the old values from 
https://github.com/Lenovo-YTX703-Devel/android_kernel_lenovo_msm8976/blob/4d98171711a09ff5438dd9f4d538b117beebfbb4/arch/arm/boot/dts/qcom/msm8976-pm.dtsi#L159
to the new ones gives the following table, which shows that the new values are returning an "expected" (residency>0) result:

|  | next_pwr->energy_overhead | base_pwr->energy_overhead  |  next_pwr->ss_power  | next_pwr->time_overhead_us  | base_pwr->ss_power  |  base_pwr->time_overhead_us | residency
| ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------ |
| old |  150122 | 64172  |  545 |  239 | 552  |  61 | -10633  |
| new |  150122 | 64172  | 540  |  241 | 552  |  81 |  522 |

Although the latter commit would be sufficient, the previous cleans up the code with a proper error handling.

Some background:
https://android.googlesource.com/kernel/msm.git/+/android-msm-shamu-3.10-lollipop-mr1/Documentation/devicetree/bindings/arm/msm/lpm-levels.txt