### PR TITLE
wlan: increase MAX_CFG_INI_ITEMS

### DIFF
--- a/drivers/staging/prima/CORE/HDD/inc/wlan_hdd_cfg.h
+++ b/drivers/staging/prima/CORE/HDD/inc/wlan_hdd_cfg.h
@@ -54,7 +54,7 @@
 #endif /* DHCP_SERVER_OFFLOAD */
 
 //Number of items that can be configured
-#define MAX_CFG_INI_ITEMS   512
+#define MAX_CFG_INI_ITEMS   530
 
 #ifdef SAP_AUTH_OFFLOAD
 /* 802.11 pre-share key length */


### PR DESCRIPTION
Currently when the driver loads it logs an error that
MAX_CFG_INI_ITEMS is too small.  So increase the value to compensate
for the configuration items that have been recently added and to allow
some future growth as well.

Silences log:
```
[   16.552900] ueventd: firmware: loading 'wlan/prima/WCNSS_qcom_cfg.ini' for '/devices/soc.0/a000000.qcom,wcnss-wlan/firmware/wlan!prima!WCNSS_qcom_cfg.ini'
[   16.553301] ueventd: loading /devices/soc.0/a000000.qcom,wcnss-wlan/firmware/wlan!prima!WCNSS_qcom_cfg.ini took 0ms
[   16.553694] wlan: [E :HDD] hdd_apply_cfg_ini: MAX_CFG_INI_ITEMS too small, must be at least 517
``` 