### PR TITLE
camera: Initialization fixes (cosmetic)

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
@@ -31,15 +31,17 @@
 		<&clock_gcc clk_csi0phytimer_clk_src>,
 		<&clock_gcc clk_gcc_camss_csi0phytimer_clk>,
 		<&clock_gcc clk_camss_top_ahb_clk_src>,
+		<&clock_gcc clk_csi2_clk_src>,
 		<&clock_gcc clk_gcc_camss_csi0phy_clk>,
 		<&clock_gcc clk_gcc_camss_csi1phy_clk>,
 		<&clock_gcc clk_gcc_camss_csi2phy_clk>,
 		<&clock_gcc clk_gcc_camss_ahb_clk>;
 		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
 		"csiphy_timer_src_clk", "csiphy_timer_clk",
-		"camss_ahb_src", "csi0_phy_clk", "csi1_phy_clk",
+		"camss_ahb_src", "csi_clk",
+		"csi0_phy_clk", "csi1_phy_clk",
 		"csi2_phy_clk", "camss_ahb_clk";
-		qcom,clock-rates = <0 61540000 200000000 0 0 0 0 0 0>;
+		qcom,clock-rates = <0 61540000 200000000 0 0 200000000 0 0 0 0>;
 	};
 
 	qcom,csiphy@1b0b000 {
@@ -55,15 +57,17 @@
 		<&clock_gcc clk_csi1phytimer_clk_src>,
 		<&clock_gcc clk_gcc_camss_csi1phytimer_clk>,
 		<&clock_gcc clk_camss_top_ahb_clk_src>,
+		<&clock_gcc clk_csi2_clk_src>,
 		<&clock_gcc clk_gcc_camss_csi0phy_clk>,
 		<&clock_gcc clk_gcc_camss_csi1phy_clk>,
 		<&clock_gcc clk_gcc_camss_csi2phy_clk>,
 		<&clock_gcc clk_gcc_camss_ahb_clk>;
 		clock-names = "camss_top_ahb_clk", "ispif_ahb_clk",
 		"csiphy_timer_src_clk", "csiphy_timer_clk",
-		"camss_ahb_src", "csi0_phy_clk", "csi1_phy_clk",
+		"camss_ahb_src", "csi_clk",
+		"csi0_phy_clk", "csi1_phy_clk",
 		"csi2_phy_clk", "camss_ahb_clk";
-		qcom,clock-rates = <0 61540000 200000000 0 0 0 0 0 0>;
+		qcom,clock-rates = <0 61540000 200000000 0 0 200000000 0 0 0 0>;
 	};
 
 	qcom,csid@1b08000  {

--- a/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
@@ -392,17 +392,18 @@
 		reg-names = "cci";
 		interrupts = <0 50 0>;
 		interrupt-names = "cci";
-		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
+		clocks = <&clock_gcc clk_camss_top_ahb_clk_src>,
+		<&clock_gcc clk_gcc_camss_top_ahb_clk>,
 		<&clock_gcc clk_cci_clk_src>,
 		<&clock_gcc clk_gcc_camss_cci_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_cci_clk>,
 		<&clock_gcc clk_gcc_camss_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_ispif_ahb_clk>;
-		clock-names = "camss_top_ahb_clk", "cci_src_clk",
+		clock-names = "camss_ahb_src", "camss_top_ahb_clk", "cci_src_clk",
 		"cci_ahb_clk", "camss_cci_clk",
 		"camss_ahb_clk", "ispif_ahb_clk";
-		qcom,clock-rates = <0 19200000 0 0 0 61540000>,
-		<0 37500000 0 0 0 61540000>;
+		qcom,clock-rates = <40000000 0 19200000 0 0 0 61540000>,
+		<80000000 0 37500000 0 0 0 61540000>;
 		pinctrl-names = "cci_default", "cci_suspend";
 		pinctrl-0 = <&cci0_active &cci1_active>;
 		pinctrl-1 = <&cci0_suspend &cci1_suspend>;

--- a/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-camera.dtsi
@@ -75,6 +75,7 @@
 		interrupt-names = "csid";
 		qcom,csi-vdd-voltage = <1800000>;
 		qcom,mipi-csi-vdd-supply = <&pm8950_l6>;
+		qcom,gdscr-vdd-supply = <&stub_camss_top_gdscr>;
 		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_csi0_ahb_clk>,
@@ -99,6 +100,7 @@
 		interrupt-names = "csid";
 		qcom,csi-vdd-voltage = <1800000>;
 		qcom,mipi-csi-vdd-supply = <&pm8950_l6>;
+		qcom,gdscr-vdd-supply = <&stub_camss_top_gdscr>;
 		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_csi1_ahb_clk>,
@@ -123,6 +125,7 @@
 		interrupt-names = "csid";
 		qcom,csi-vdd-voltage = <1800000>;
 		qcom,mipi-csi-vdd-supply = <&pm8950_l6>;
+		qcom,gdscr-vdd-supply = <&stub_camss_top_gdscr>;
 		clocks = <&clock_gcc clk_gcc_camss_top_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_ispif_ahb_clk>,
 		<&clock_gcc clk_gcc_camss_csi2_ahb_clk>,
@@ -392,6 +395,7 @@
 		reg-names = "cci";
 		interrupts = <0 50 0>;
 		interrupt-names = "cci";
+		qcom,gdscr-vdd-supply = <&stub_camss_top_gdscr>;
 		clocks = <&clock_gcc clk_camss_top_ahb_clk_src>,
 		<&clock_gcc clk_gcc_camss_top_ahb_clk>,
 		<&clock_gcc clk_cci_clk_src>,

--- a/arch/arm/boot/dts/qcom/msm8976-regulator.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8976-regulator.dtsi
@@ -693,4 +693,11 @@
 		enable-avtive-high;
 		gpio = <&pm8004_mpps 4 0>;
 	};
+
+	stub_camss_top_gdscr: stub_gdscr {
+		compatible = "qcom,stub-regulator";
+		regulator-name = "gdscr";
+		regulator-min-microvolt = <1>;
+		regulator-max-microvolt = <1800000>;
+	};
 };


### PR DESCRIPTION
### Part1: camera: msm8976-camera: Add camss_top_ahb_clk_src to CPP node

This makes the clock sequence to be correct at boot and will
stop the kernel warning at CPP first init.

Inspired by
https://github.com/sonyxperiadev/kernel/commit/ce879415318cd4155c1f18ddfade364414341f65

Clock rates where taken from the clock definitions:
https://source.codeaurora.org/quic/chrome/kernel/msm-3.10/tree/drivers/clk/qcom/clock-gcc-8976.c?h=LA.BR.1.3.7-05010-8976.0#n891

Fixes warning when initializing camera interface:
```
[    1.114223] msm_cci_get_clk_info: clock-names[0][0] = camss_top_ahb_clk
[    1.114345] msm_cci_get_clk_info: clk_rate[0][0] = -1
[    1.114410] msm_cci_get_clk_info: clock-names[0][1] = cci_src_clk
[    1.114531] msm_cci_get_clk_info: clk_rate[0][1] = 19200000
[    1.114597] msm_cci_get_clk_info: clock-names[0][2] = cci_ahb_clk
[    1.114716] msm_cci_get_clk_info: clk_rate[0][2] = -1
[    1.114781] msm_cci_get_clk_info: clock-names[0][3] = camss_cci_clk
[    1.114901] msm_cci_get_clk_info: clk_rate[0][3] = -1
[    1.114965] msm_cci_get_clk_info: clock-names[0][4] = camss_ahb_clk
[    1.115083] msm_cci_get_clk_info: clk_rate[0][4] = -1
[    1.115148] msm_cci_get_clk_info: clock-names[0][5] = ispif_ahb_clk
[    1.115268] msm_cci_get_clk_info: clk_rate[0][5] = 61540000
[    1.115332] msm_cci_get_clk_info: clock-names[1][0] = camss_top_ahb_clk
[    1.115452] msm_cci_get_clk_info: clk_rate[1][0] = -1
[    1.115516] msm_cci_get_clk_info: clock-names[1][1] = cci_src_clk
[    1.115636] msm_cci_get_clk_info: clk_rate[1][1] = 37500000
[    1.115702] msm_cci_get_clk_info: clock-names[1][2] = cci_ahb_clk
[    1.115822] msm_cci_get_clk_info: clk_rate[1][2] = -1
[    1.115887] msm_cci_get_clk_info: clock-names[1][3] = camss_cci_clk
[    1.116007] msm_cci_get_clk_info: clk_rate[1][3] = -1
[    1.116072] msm_cci_get_clk_info: clock-names[1][4] = camss_ahb_clk
[    1.116192] msm_cci_get_clk_info: clk_rate[1][4] = -1
[    1.116257] msm_cci_get_clk_info: clock-names[1][5] = ispif_ahb_clk
[    1.116377] msm_cci_get_clk_info: clk_rate[1][5] = 61540000
[    1.118703] adp1660 i2c_add_driver success
[    1.119282] msm_torch_create_classdev:135 Invalid fctrl->torch_trigger[0]
[    1.119414] qcom,camera-flash: probe of qcom,camera-flash.105 failed with error -22
[    1.119620] msm_flash_lm3642_init entry
[    1.121655] msm_cci_init: Failed in getting TOP gdscr regulator handle
[    1.121802] ------------[ cut here ]------------
[    1.121940] WARNING: at /../drivers/clk/qcom/clock-local2.c:216 rcg_clk_enable+0x50/0xa0()
[    1.122062] Attempting to prepare camss_top_ahb_clk_src before setting its rate. Set the rate first!
[    1.122183] Modules linked in:
[    1.122312] CPU: 4 PID: 1 Comm: swapper/0 Tainted: G        W    3.10.108_LA.BR.1.3.7_rb1.11+ #45
[    1.122433] Call trace:
[    1.122500] [<ffffffc000087dcc>] dump_backtrace+0x0/0x26c
[    1.122621] [<ffffffc00008804c>] show_stack+0x14/0x1c
[    1.122688] [<ffffffc000d0da50>] dump_stack+0x20/0x28
[    1.122810] [<ffffffc00009dda0>] warn_slowpath_common+0x78/0x9c
[    1.122875] [<ffffffc00009de14>] warn_slowpath_fmt+0x50/0x58
[    1.122996] [<ffffffc0009fc900>] rcg_clk_enable+0x50/0xa0
[    1.123061] [<ffffffc0009f9afc>] clk_enable+0x174/0x1b4
[    1.123180] [<ffffffc0009f9a24>] clk_enable+0x9c/0x1b4
[    1.123247] [<ffffffc000672084>] msm_cam_clk_enable+0x164/0x290
[    1.123367] [<ffffffc000670be8>] msm_cci_config+0x530/0x12e0
[    1.123432] [<ffffffc000671a40>] msm_cci_subdev_ioctl+0xa8/0xf0
[    1.123554] [<ffffffc000673e54>] msm_sensor_cci_i2c_util+0x78/0xc8
[    1.123620] [<ffffffc000678df0>] msm_camera_power_up+0x4e4/0x764
[    1.123740] [<ffffffc000686ed0>] msm_eeprom_platform_probe+0x3f8/0x5f8
[    1.123807] [<ffffffc000489420>] platform_drv_probe+0x18/0x20
[    1.123928] [<ffffffc000487f90>] driver_probe_device+0x164/0x374
[    1.123994] [<ffffffc000488250>] __driver_attach+0x64/0x90
[    1.124115] [<ffffffc000486d80>] bus_for_each_dev+0x74/0x90
[    1.124181] [<ffffffc0004878d0>] driver_attach+0x20/0x28
[    1.124302] [<ffffffc000487480>] bus_add_driver+0x120/0x240
[    1.124368] [<ffffffc000488870>] driver_register+0x94/0x110
[    1.124491] [<ffffffc0004898f8>] platform_driver_register+0x5c/0x64
[    1.124557] [<ffffffc00048993c>] platform_driver_probe+0x24/0x9c
[    1.124680] [<ffffffc0014555dc>] msm_eeprom_init_module+0x50/0xd8
[    1.124746] [<ffffffc000081910>] do_one_initcall+0xb4/0x158
[    1.124806] synaptics_rmi4_sensor_report: spontaneous reset detected
[    1.124982] [<ffffffc00141e908>] kernel_init_freeable+0x148/0x1e8
[    1.125038] [<ffffffc000d038ec>] kernel_init+0x14/0xcc
[    1.125159] ---[ end trace da227214a82491b8 ]---
```

### Part2: camera: Add stub regulators for camera's gdscr.

Although regulators are optional in camera drivers,
there is a warning each time the camera initializes,
which indicates an error, by not getting the TOP gdscr regulator handle.

[    1.118752] msm_cci_init: Failed in getting TOP gdscr regulator handle

MSM8976 has no additional gdscr (gdsc) vregs,
so stub them out and silence the error.

Inspired by:
https://github.com/sonyxperiadev/kernel/commit/59813018215991829406ad85c988ca2aa33ece5c