### PR TITLE
power: qcom: pm-boot: Change WARN to pr_warn to avoid stack dump

### DIFF
--- a/drivers/power/qcom/pm-boot.c
+++ b/drivers/power/qcom/pm-boot.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2014, 2016, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -42,7 +42,8 @@ static int msm_pm_tz_boot_init(void)
 			flag = SCM_FLAG_WARMBOOT_CPU0 | SCM_FLAG_WARMBOOT_CPU1 |
 				SCM_FLAG_WARMBOOT_CPU2 | SCM_FLAG_WARMBOOT_CPU3;
 		else
-			__WARN();
+			pr_warn("%s: set warmboot address failed\n",
+								__func__);
 
 		return scm_set_boot_addr(virt_to_phys(msm_pm_boot_entry), flag);
 	}


### PR DESCRIPTION
Only non-psci based targets need to set warmboot address from pm-boot.
Change WARN to pr_warn as former prints stack and register dump in logs
which is not necessary.

Changes:
```
[    0.522716] ------------[ cut here ]------------
[    0.522914] WARNING: at ../drivers/power/qcom/pm-boot.c:45 msm_pm_boot_init+0x90/0xd0()
[    0.523095] Modules linked in:
[    0.523296] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 3.10.108_LA.BR.1.3.7_rb1.11+ #45
[    0.523479] Call trace:
[    0.523587] [<ffffffc000087dcc>] dump_backtrace+0x0/0x26c
[    0.523775] [<ffffffc00008804c>] show_stack+0x14/0x1c
[    0.523879] [<ffffffc000d0da50>] dump_stack+0x20/0x28
[    0.523985] [<ffffffc00009dda0>] warn_slowpath_common+0x78/0x9c
[    0.524171] [<ffffffc00009dfdc>] warn_slowpath_null+0x18/0x20
[    0.524272] [<ffffffc0014562a8>] msm_pm_boot_init+0x90/0xd0
[    0.524459] [<ffffffc000081910>] do_one_initcall+0xb4/0x158
[    0.524564] [<ffffffc00141e908>] kernel_init_freeable+0x148/0x1e8
[    0.524752] [<ffffffc000d038ec>] kernel_init+0x14/0xcc
[    0.524871] ---[ end trace da227214a82491b7 ]---
```
into:
`[    0.523763] msm_pm_tz_boot_init: set warmboot address failed`

Note: After the warning in new/old implementations, there is a call
to the scm, which always fails and this isn't part of this commit:
scm_call failed with error code -1

At this point it is reasonable to change the warning text, according to the original commit description, since we the 8976 is a psci target (  https://github.com/Lenovo-YTX703-Devel/android_kernel_lenovo_msm8976/blob/4d98171711a09ff5438dd9f4d538b117beebfbb4/arch/arm/boot/dts/qcom/msm8976-cpu.dtsi#L60 ).