### PR TITLE
Control backlight through panel controller.

### DIFF
--- a/arch/arm/boot/dts/qcom/YTX703.dtsi
+++ b/arch/arm/boot/dts/qcom/YTX703.dtsi
@@ -170,8 +170,9 @@
 		compatible = "ti,lp8557";
 		reg = <0x2c>;
 		bl-name = "lcd-bl";
-		dev-ctrl = /bits/ 8 <0x07>; /* see lp8557 documentation */
-		init-brt = /bits/ 8 <0x40>; /* 25% brightness */
+		dev-ctrl = /bits/ 8 <0x00>; /* see lp8557 documentation, PWM mode only */
+		init-brt = /bits/ 8 <0x00>; /* 0% initial brightness */
+		pwm-period = <1000000>; /* value from documentation, doesn't seem to have an effect */
 		 /* enable spread-spectrum boost clocking (reduces flickering): */
 		rom_00h {
 			rom-addr = /bits/ 8 <0x00>;
@@ -273,6 +274,10 @@
 		qcom,mdss-dsi-v-back-porch  = <24>;
 		qcom,mdss-dsi-v-front-porch = <16>;
 		qcom,mdss-dsi-v-pulse-width = <8>;
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs"; // control backlight via dsi commands
+		/* Backlight controller operates in range 0<x<256 */
+		qcom,mdss-dsi-bl-min-level = <0x01>;
+		qcom,mdss-dsi-bl-max-level = <0xFF>;
 		qcom,mdss-dsi-on-command = [
 			39 01 00 00 01 00 06 f0 55 aa 52 08 00
 			15 01 00 00 01 00 02 c0 0d
@@ -283,10 +288,11 @@
 			39 01 00 00 01 00 05 ff aa 55 a5 00
 			15 01 00 00 01 00 02 62 01
 			15 01 00 00 01 00 02 55 00 //CABC mode (0:off, 1:UI, 2:picture, 3:video), p.229
-			15 01 00 00 01 00 02 53 24
-			15 01 00 00 01 00 02 51 80
 			05 01 00 00 78 00 02 11 00
-			05 01 00 00 15 00 02 29 00];
+			05 01 00 00 15 00 02 29 00
+			15 01 00 00 01 00 02 51 00 // initial brightness set to 0
+			15 01 00 00 01 00 02 53 24 // turn the lights on
+		];
 		qcom,mdss-dsi-panel-timings = [D5 32 22 00 60 64 26 34 29 03 04 00]; //MIPICLL 399
 	};
 };


### PR DESCRIPTION
For image enhancements (CABC) the panel needs to control
the backlight by itself. Also controlling the brightness
via the panel controller gives the ability to apply some
brightness dimming improvements which the panel provides.

Luckily on our device it is connected to the PWM of the
backlight and can send the brightness values to that
directly.
The backlight is configured to use the brightness values
from the PWM only.
The panel is configured to be informed about brightness change
via dedicated DSI commands, which are sent by the mdss-dsi
panel driver.
The initial backlight value for the panel is set to zero,
which otherwise causes the backlight goes on and shows a
black screen until the display is ready.
Also the panel on commands where set as late as possible
to let the display initialize in the meantime to reduce
the previous mentioned effect.